### PR TITLE
Deleted <br> HTML tag from MarkDown files, because Dymola gets confused.

### DIFF
--- a/DC-Motor/contents/extra/org.ssp-standard.ssp-traceability.stmd/3-3-Request-CSP-Design-Inputs.md
+++ b/DC-Motor/contents/extra/org.ssp-standard.ssp-traceability.stmd/3-3-Request-CSP-Design-Inputs.md
@@ -1,7 +1,6 @@
 **Request input**
 **(there can be additional input be part of the simulation request)**
 
-<br>
 **Phase 3 step 3 Define Design Specification Parameters**
 
 **Inputs:**

--- a/DC-Motor/contents/extra/org.ssp-standard.ssp-traceability.stmd/3-5-Request-CSP-Design-Inputs.md
+++ b/DC-Motor/contents/extra/org.ssp-standard.ssp-traceability.stmd/3-5-Request-CSP-Design-Inputs.md
@@ -1,7 +1,6 @@
 **Request input**
 **(there can be additional input be part of the simulation request)**
 
-<br>
 **Phase 3 step 5 Define Design Specification Simulation Environment**
 
 **Inputs:**


### PR DESCRIPTION
It should not be significant change to the documentation. In some future version Dymola will be able to handle the <br> tag, but not right now.